### PR TITLE
feat(teams): add getOrCreateTodayMatch mutation

### DIFF
--- a/schema.gql
+++ b/schema.gql
@@ -1045,6 +1045,9 @@ type Mutation {
   removeTeamMember(teamId: ID!, userId: ID!): Boolean!
   updateMemberRole(teamId: ID!, userId: ID!, role: String!): TeamMember!
   createMatch(input: CreateMatchInput!): TeamMatch!
+
+  """Get existing match for today or create one if none exists"""
+  getOrCreateTodayMatch(teamId: ID!): TeamMatch!
   updateMatch(id: ID!, input: UpdateMatchInput!): TeamMatch!
   deleteMatch(id: ID!): Boolean!
   uploadPhoto(matchId: ID!, file: Upload!, category: String, isHighlight: Boolean = false): Media!

--- a/src/teams/teams.resolver.ts
+++ b/src/teams/teams.resolver.ts
@@ -166,6 +166,15 @@ export class TeamsResolver {
     return this.teamsService.createMatch(user.userId, input);
   }
 
+  @Mutation(() => TeamMatch, { description: 'Get existing match for today or create one if none exists' })
+  @UseGuards(GqlAuthGuard)
+  async getOrCreateTodayMatch(
+    @Args('teamId', { type: () => ID }) teamId: string,
+    @CurrentUser() user: CurrentUserPayload,
+  ): Promise<TeamMatch> {
+    return this.teamsService.getOrCreateTodayMatch(user.userId, teamId);
+  }
+
   @Mutation(() => TeamMatch)
   @UseGuards(GqlAuthGuard)
   async updateMatch(


### PR DESCRIPTION
- Adds new mutation to get existing match for today or create one
- Reuses existing match if one exists for the current date
- Simplifies upload flow for web and mobile apps